### PR TITLE
changed asset names from m<asset> to u<asset>

### DIFF
--- a/src/pages/PageAccount.vue
+++ b/src/pages/PageAccount.vue
@@ -21,7 +21,7 @@
             ul.chart
               li(v-for="coin in coins")
                 div.inner
-                  span {{ mlunaToLuna(coin.amount) }} {{ denomSlicer(coin.denom) }}
+                  span {{ rebaseAsset(coin.amount) }} {{ denomSlicer(coin.denom) }}
 
         tm-list-item(dt="Delegations")
           template(slot="dd")
@@ -37,10 +37,10 @@
               li(v-for="d in delegations")
                 ul.row
                   li {{ d.validator_address }}
-                  li {{ mlunaToLuna(d.shares) }} Luna
+                  li {{ rebaseAsset(d.shares) }} Luna
                   li
                     p(v-for="reward in d.rewards")
-                      span {{ mlunaToLuna(reward.amount) }} {{ denomSlicer(reward.denom) }}
+                      span {{ rebaseAsset(reward.amount) }} {{ denomSlicer(reward.denom) }}
               div(class="table-empty", v-if="delegations.length === 0") {{ `No delegation yet` }}
 
         tm-list-item(dt="Transactions")
@@ -83,7 +83,7 @@ import { isEmpty } from "lodash";
 import Clipboard from "clipboard";
 
 import { format } from "../scripts/utility";
-import { shortNumber, mlunaToLuna, denomSlicer } from "../scripts/num";
+import { shortNumber, rebaseAsset, denomSlicer } from "../scripts/num";
 import TmListItem from "../components/TmListItem";
 import AppHeader from "../components/AppHeader";
 import AppPage from "../components/AppPage";
@@ -128,7 +128,7 @@ export default {
     format,
     shortNumber,
     denomSlicer,
-    mlunaToLuna,
+    rebaseAsset,
     copy() {
       this.copied = true;
       setTimeout(() => {

--- a/src/pages/PageTransaction.vue
+++ b/src/pages/PageTransaction.vue
@@ -24,7 +24,7 @@
         tm-list-item(dt="Timestamp" :dd="`${format(transaction.timestamp)} (UTC)`")
         //- tm-list-item(dt="Sender" :dd="transaction.tx.value.msg[0].value.from_address")
         //- tm-list-item(dt="Receiver" :dd="transaction.tx.value.msg[0].value.to_address")
-        tm-list-item(dt="Transaction fee" :dd="transaction.tx.value.fee.amount ? `${mlunaToLuna(transaction.tx.value.fee.amount[0].amount)} LUNA` : `Null`")
+        tm-list-item(dt="Transaction fee" :dd="transaction.tx.value.fee.amount ? `${rebaseAsset(transaction.tx.value.fee.amount[0].amount)} LUNA` : `Null`")
         tm-list-item(dt="Gas (Used/Requested)" :dd="`${parseInt(transaction.gas_used).toLocaleString()}/${parseInt(transaction.gas_wanted).toLocaleString()}`")
         tm-list-item.rawData(dt="Message")
           template(slot="dd" v-for="m in transaction.tx.value.msg")
@@ -46,7 +46,7 @@ import { mapGetters, mapActions } from "vuex";
 import { isEmpty } from "lodash";
 import Clipboard from "clipboard";
 import { isTerraAddress, format } from "../scripts/utility";
-import { denomSlicer, mlunaToLuna } from "../scripts/num";
+import { denomSlicer, rebaseAsset } from "../scripts/num";
 import TmListItem from "../components/TmListItem";
 import AppHeader from "../components/AppHeader";
 import AppNotFound from "../components/AppNotFound";
@@ -80,7 +80,7 @@ export default {
     isEmpty,
     isTerraAddress,
     denomSlicer,
-    mlunaToLuna,
+    rebaseAsset,
     format,
     copy() {
       this.copied = true;
@@ -89,7 +89,7 @@ export default {
       }, 1500);
     },
     stringify({ denom, amount } = {}) {
-      return [mlunaToLuna(amount), this.denomSlicer(denom)].join(" ");
+      return [rebaseAsset(amount), this.denomSlicer(denom)].join(" ");
     }
   },
   async created() {

--- a/src/pages/PageTransactions.vue
+++ b/src/pages/PageTransactions.vue
@@ -30,7 +30,7 @@
               div {{ tx.tx.type }}
               span(v-if="tx.tx.value.msg.length > 1") {{ `+ ${tx.tx.value.msg.length - 1}` }}
             li
-              p.txfee {{ tx.tx.value.fee.amount ? `${mlunaToLuna(tx.tx.value.fee.amount[0].amount)} LUNA` : `Null` }}
+              p.txfee {{ tx.tx.value.fee.amount ? `${rebaseAsset(tx.tx.value.fee.amount[0].amount)} LUNA` : `Null` }}
             li
               router-link.block(:to="{ name: 'block', params: { block: tx.height }}") {{ tx.height }}
             li
@@ -50,7 +50,7 @@ import AppPage from "../components/AppPage";
 import AppNotFound from "../components/AppNotFound";
 import AppLoading from "../components/AppLoading";
 import { txToHash, fromNow } from "../scripts/utility";
-import { mlunaToLuna } from "../scripts/num";
+import { rebaseAsset } from "../scripts/num";
 
 export default {
   beforeCreate: function() {
@@ -99,7 +99,7 @@ export default {
     ...mapActions(["queryTxs", "fetchBlock"]),
     fromNow,
     isEmpty,
-    mlunaToLuna,
+    rebaseAsset,
     pageChange({ pageNumber, pageSize }) {
       this.startIndex = pageSize * (pageNumber - 1);
       this.endIndex = pageSize * pageNumber;

--- a/src/scripts/num.js
+++ b/src/scripts/num.js
@@ -8,7 +8,7 @@ export function shortNumber(num) {
   return numeral(num).format(`0,0.0000`) + ``;
 }
 
-export function mlunaToLuna(num) {
+export function rebaseAsset(num) {
   return BigNumber(num)
     .dividedBy(Math.pow(10, 6))
     .decimalPlaces(6)
@@ -16,15 +16,9 @@ export function mlunaToLuna(num) {
 }
 
 export function denomSlicer(str) {
-  const converter = {
-    mluna: "Luna",
-    mkrw: "KRT",
-    musd: "UST",
-    msdr: "SDT",
-    mgbp: "GBT",
-    meur: "EUT",
-    mjpy: "JPT",
-    mcny: "CNT"
-  };
-  return converter[str];
+  var frag = str.slice(1);
+  if (frag == "luna") {
+    return "LUNA"
+  }
+  return frag.slice(0, 2).toUpperCase() + "T"
 }


### PR DESCRIPTION
## Summary

Currently, on-chain assets were defined as "musd" "mluna" for 10^-6 th of the parent asset. For micro units, the convention is to prefix 'u' instead of 'm'

https://en.wikipedia.org/wiki/International_System_of_Units#Prefixes

## Fix

- Changed all asset prefixes to support any arbitrary asset prefixes (denomSlicer function updated)
- Minor refactoring
